### PR TITLE
Add author attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codespaces Dotfiles Template
 
+**Author:** Jose
+
 Test
 This repo is a starting point for using custom dotfiles (terminal / editor configuration) with GitHub Codespaces
 


### PR DESCRIPTION
Added author attribution to the README to properly credit the repository owner.

## Changes
- Added `**Author:** Jose` below the main title in README.md

```markdown
# Codespaces Dotfiles Template

**Author:** Jose

Test
This repo is a starting point for using custom dotfiles...
```