### PR TITLE
Add author attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ This supports the following tools:
 ## Vim Plugins
 
 This repo uses the wonderful [Vim Plug](https://github.com/junegunn/vim-plug) tool to manage vim plugins. If you'd like to add plugins, simply add them between the opening and closing plug statements in the `vimrc` file.
+
+## Author
+
+Jose


### PR DESCRIPTION
Repository lacked author information. Added attribution section to document ownership.

## Changes
- Added "Author" section at end of README
- Listed Jose as repository owner

```markdown
## Author

Jose
```