### PR TITLE
Add maintainer attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codespaces Dotfiles Template
 
+**Maintained by:** Jose
+
 Test
 This repo is a starting point for using custom dotfiles (terminal / editor configuration) with GitHub Codespaces
 


### PR DESCRIPTION
Added maintainer attribution to improve repository ownership clarity.

## Changes

- Added "Maintained by: Jose" below the title in README.md

```markdown
# Codespaces Dotfiles Template

**Maintained by:** Jose
```