### PR TITLE
Add author attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codespaces Dotfiles Template
 
+**Author:** Jose
+
 Test
 This repo is a starting point for using custom dotfiles (terminal / editor configuration) with GitHub Codespaces
 


### PR DESCRIPTION
Added author credit to the README to properly attribute the dotfiles repository.

**Changes:**
- Added `**Author:** Jose` line below the main heading in README.md