### PR TITLE
Add author name to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codespaces Dotfiles Template
 
+Jose
+
 Test
 This repo is a starting point for using custom dotfiles (terminal / editor configuration) with GitHub Codespaces
 


### PR DESCRIPTION
Added author attribution to the README for project ownership clarity.

## Changes
- Added "Jose" below the main heading in README.md to indicate authorship

The name appears immediately after the title, maintaining the existing document structure.